### PR TITLE
Disable the translation bot in this repository

### DIFF
--- a/translation-bot.json
+++ b/translation-bot.json
@@ -1,0 +1,3 @@
+{
+    "disabled": true
+}


### PR DESCRIPTION
This PR depends on https://github.com/solidity-docs/translation-guide/pull/28, which will allow configuring the translation bot. Note that the changes won't really take effect until that other PR is merged.

I think that the only change from the defaults that's needed for now is to temporarily disable the bot as I suggested in https://github.com/solidity-docs/ja-japanese/pull/14#issuecomment-1193387627 but please take a look at the updated README in https://github.com/solidity-docs/translation-guide/pull/28. It shows which other things you can configure in this file. Let me know if you want anything added. Otherwise you can merge it right away.
