### PR TITLE
Clean `.gitignore` for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,63 +1,9 @@
-commit_hash.txt
-prerelease.txt
+# Built docs
+/docs/_build
 
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
+# Automatically generated robots.txt
+/docs/_static/robots.txt
 
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
-# Build directory
-/build*
-emscripten_build/
-docs/_build
-docs/_static/robots.txt
+# Python bytecode
+*.pyc
 __pycache__
-docs/utils/*.pyc
-/deps/downloads/
-deps/install
-deps/cache
-cmake-build-*/
-
-# vim stuff
-[._]*.sw[a-p]
-[._]sw[a-p]
-
-# emacs stuff
-*~
-
-# IDE files
-.idea
-.vscode
-browse.VC.db
-CMakeLists.txt.user
-/CMakeSettings.json
-/.vs
-/.cproject
-/.project
-
-# place to put local temporary files
-tmp


### PR DESCRIPTION
Here's a cleaner `.gitignore` file more suited for a docs-only repo. A lot of stuff in the original one is only relevant for compiler development.

Feel free to also add other stuff that's relevant to your particular workflow.