### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+  - epub
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/ext/remix_code_links.py
+++ b/docs/ext/remix_code_links.py
@@ -27,10 +27,10 @@ def remix_code_url(source_code, language, solidity_version):
 
 def build_remix_link_node(url):
     reference_node = docutils.nodes.reference('', 'open in Remix', internal=False, refuri=url, target='_blank')
-    reference_node.set_class('remix-link')
+    reference_node['classes'].append('remix-link')
 
     paragraph_node = docutils.nodes.paragraph()
-    paragraph_node.set_class('remix-link-container')
+    paragraph_node['classes'].append('remix-link-container')
     paragraph_node.append(reference_node)
     return paragraph_node
 


### PR DESCRIPTION
This PR adds the missing `.readthedocs.yml` configuration file, which is now required to build the documentation. For reference, see https://github.com/solidity-docs/zh-chinese/pull/279.

It also includes a hotfix that removes the deprecated `set_class` from the `remix_code_links` extension. For more details, see https://github.com/solidity-docs/zh-chinese/pull/380 and https://github.com/ethereum/solidity/pull/14706

You can view a successful test build here: https://app.readthedocs.org/projects/ja-japanese/builds/25980434/